### PR TITLE
Doc updates

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -947,7 +947,7 @@ FILE_PATTERNS          = *.c \
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -972,7 +972,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = *.txt
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/supported_specifiers.md
+++ b/docs/supported_specifiers.md
@@ -1,5 +1,6 @@
 # Supported Format Specifiers
+The following list of characters that follow a % symbol will signify that the corresponding argument is of a certain datatype.
 
-- `@%F` and `@%D` specifies a double.
-- `@%s` and `@%S` specifies a string.
-- `@%d` and `@%i` specifies an integer.
+- `F` and `D` specifies a double.
+- `s` and `S` specifies a string.
+- `d` and `i` specifies an integer.

--- a/docs/supported_specifiers.md
+++ b/docs/supported_specifiers.md
@@ -1,0 +1,5 @@
+# Supported Format Specifiers
+
+- `@%F` and `@%D` specifies a double.
+- `@%s` and `@%S` specifies a string.
+- `@%d` and `@%i` specifies an integer.

--- a/docs/supported_specifiers.md
+++ b/docs/supported_specifiers.md
@@ -1,5 +1,5 @@
 # Supported Format Specifiers
-The following list of characters that follow a % symbol will signify that the corresponding argument is of a certain datatype.
+The following list of characters that immediately follow a % symbol will signify that the corresponding argument is of a certain datatype.
 
 - `F` and `D` specifies a double.
 - `s` and `S` specifies a string.

--- a/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
+++ b/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
@@ -1,6 +1,4 @@
 /**
- * @file AllLogLevelsLogger.ino
- *
  * Created on: 31 Mar 2021
  *     Author: Witold Markowski (wmarkow)
  *

--- a/examples/BasicSerialLogger/BasicSerialLogger.ino
+++ b/examples/BasicSerialLogger/BasicSerialLogger.ino
@@ -205,7 +205,7 @@ void logFloatNumber()
                    "error log with double value %D", 3.14);
 
   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-                   "debug log with double value %F", 2.71);
+                   "debug log with double value %%f", 2.71);
 
   Serial.println();
 }

--- a/examples/BasicSerialLogger/BasicSerialLogger.ino
+++ b/examples/BasicSerialLogger/BasicSerialLogger.ino
@@ -1,6 +1,4 @@
 /**
- * @file BasicSerialLogger.ino
- *
  * Created on: 2 Oct 2020
  *     Author: Witold Markowski (wmarkow)
  *

--- a/examples/BasicSerialLogger/BasicSerialLogger.ino
+++ b/examples/BasicSerialLogger/BasicSerialLogger.ino
@@ -205,7 +205,7 @@ void logFloatNumber()
                    "error log with double value %D", 3.14);
 
   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-                   "debug log with double value %%f", 2.71);
+                   "debug log with double value %F", 2.71);
 
   Serial.println();
 }

--- a/examples/DualLogger/DualLogger.ino
+++ b/examples/DualLogger/DualLogger.ino
@@ -1,6 +1,4 @@
 /**
- * @file DualLogger.ino
- *
  * Created on: 30 Mar 2021
  *     Author: Witold Markowski (wmarkow)
  *

--- a/examples/EmptyLogger/EmptyLogger.ino
+++ b/examples/EmptyLogger/EmptyLogger.ino
@@ -1,6 +1,4 @@
 /**
- * @file EmptyLogger.ino
- *
  * Created on: 21 Oct 2020
  *     Author: Witold Markowski (wmarkow)
  *

--- a/examples/LogLevelsLogger/LogLevelsLogger.ino
+++ b/examples/LogLevelsLogger/LogLevelsLogger.ino
@@ -1,6 +1,4 @@
 /**
- * @file LogLevelsLogger.ino
- *
  * Created on: 31 Mar 2021
  *     Author: Witold Markowski (wmarkow)
  *

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=RF24Log is a logging library that bridges the gap between Arduino and L
 paragraph=RF24Log is a logging library that bridges the gap between Arduino and Linux platforms.
 category=Log
 url=https://github.com/nRF24/RF24Log
-architectures=* # this lib hasn't been fully tested on all platforms
+architectures=*

--- a/src/RF24LogHandler.h
+++ b/src/RF24LogHandler.h
@@ -59,7 +59,7 @@ public:
      * set the maximal level of the logged messages.
      * @param logLevel The verbosity level used to filter which of the logged messages
      * are output.
-     * @see Review the descriptions in the @ref RF24LogLevel
+     * @see Review the descriptions in the @ref logLevels
      */
     virtual void setLogLevel(uint8_t logLevel);
 };

--- a/src/RF24LogHandler.h
+++ b/src/RF24LogHandler.h
@@ -33,7 +33,10 @@ public:
      * @brief log a message.
      * @param logLevel the level of the logging message
      * @param vendorId The prefixed origin of the message
-     * @param message The message
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param args the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     virtual void log(uint8_t logLevel,
                      const __FlashStringHelper *vendorId,
@@ -44,18 +47,23 @@ public:
      * @brief log a message.
      * @param logLevel the level of the logging message
      * @param vendorId The prefixed origin of the message
-     * @param message The message
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param args the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     virtual void log(uint8_t logLevel,
                      const __FlashStringHelper *vendorId,
                      const __FlashStringHelper *message,
                      va_list *args);
 
-      /**
-       * set the maximal level of the logged messages.
-       * @param logLevel maximal level of the logged message
-       */
-      virtual void setLogLevel(uint8_t logLevel);
+    /**
+     * set the maximal level of the logged messages.
+     * @param logLevel The verbosity level used to filter which of the logged messages
+     * are output.
+     * @see Review the descriptions in the @ref RF24LogLevel
+     */
+    virtual void setLogLevel(uint8_t logLevel);
 };
 
 #endif /* SRC_RF24LOGHANDLER_H_ */

--- a/src/RF24LogHandler.h
+++ b/src/RF24LogHandler.h
@@ -34,7 +34,7 @@ public:
      * @param logLevel the level of the logging message
      * @param vendorId The prefixed origin of the message
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param args the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -48,7 +48,7 @@ public:
      * @param logLevel the level of the logging message
      * @param vendorId The prefixed origin of the message
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param args the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */

--- a/src/RF24LogHandler.h
+++ b/src/RF24LogHandler.h
@@ -31,11 +31,10 @@ class RF24LogHandler
 public:
     /**
      * @brief log a message.
-     * @param logLevel the level of the logging message
+     * @param logLevel The level of the logging message
      * @param vendorId The prefixed origin of the message
-     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
-     * @param args the sequence of variables used to replace the format specifiers in the
+     * @param message The message format string. Review [the supported printf spcifiers](md_docs_supported_specifiers.html).
+     * @param args The sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
     virtual void log(uint8_t logLevel,
@@ -45,11 +44,10 @@ public:
 
     /**
      * @brief log a message.
-     * @param logLevel the level of the logging message
+     * @param logLevel The level of the logging message
      * @param vendorId The prefixed origin of the message
-     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
-     * @param args the sequence of variables used to replace the format specifiers in the
+     * @param message The message format string. Review [the supported printf spcifiers](md_docs_supported_specifiers.html).
+     * @param args The sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
     virtual void log(uint8_t logLevel,

--- a/src/RF24LogLevel.h
+++ b/src/RF24LogLevel.h
@@ -20,7 +20,18 @@
 
 #include <stdint.h>
 
-/** the predefined logging levels */
+/**
+ * @brief the predefined logging levels
+ *
+ * These named levels are the base or parent levels. They increment in in octal counts of `010`.
+ * Each base level can have up to 7 additional sublevels. <br>For example:
+ * - a level of 031 is the first sublevel of @ref INFO verbosity
+ * - a level of 037 is the last sublevel of @ref INFO verbosity
+ *
+ * If the log level is configured for a verbosty of `020` prevents outputting all messages designated for
+ * any log level greater than `020`.
+ * @note the @ref DEBUG base level is the only level that allows 223 additional sublevels.
+ */
 enum RF24LogLevel : uint8_t
 {
     /** the level to disable all log messages */

--- a/src/RF24LogLevel.h
+++ b/src/RF24LogLevel.h
@@ -33,7 +33,6 @@
  *
  * If the log level is configured (using RF24LogHandler::setLogLevel()) for a verbosty of `020` prevents outputting all messages designated for
  * any log level greater than `020`.
- * @note the @ref DEBUG base level is the only level that allows 223 additional sublevels.
  */
 enum RF24LogLevel : uint8_t
 {

--- a/src/RF24LogLevel.h
+++ b/src/RF24LogLevel.h
@@ -19,7 +19,10 @@
 #define SRC_RF24LOGLEVEL_H_
 
 #include <stdint.h>
-
+/**
+ * @defgroup logLevels Log Levels
+ * @{
+ */
 /**
  * @brief the predefined logging levels
  *
@@ -28,24 +31,24 @@
  * - a level of 031 is the first sublevel of @ref INFO verbosity
  * - a level of 037 is the last sublevel of @ref INFO verbosity
  *
- * If the log level is configured for a verbosty of `020` prevents outputting all messages designated for
+ * If the log level is configured (using RF24LogHandler::setLogLevel()) for a verbosty of `020` prevents outputting all messages designated for
  * any log level greater than `020`.
  * @note the @ref DEBUG base level is the only level that allows 223 additional sublevels.
  */
 enum RF24LogLevel : uint8_t
 {
-    /** the level to disable all log messages */
-    OFF = 0x00,
-    /** the level to specify an error message */
-    ERROR = 0x08,
-    /** the level to specify an warning message */
-    WARN = 0x10,
-    /** the level to specify an informational message */
-    INFO = 0x18,
-    /** the level to specify an debugging message */
-    DEBUG = 0x20,
-    /** the level to enable all log messages (disables filtering of levels) */
+    /** (`0`) the level to disable all log messages */
+    OFF = 0,
+    /** (`010`) the level to specify an error message */
+    ERROR = 010,
+    /** (`020`) the level to specify an warning message */
+    WARN = 020,
+    /** (`030`) the level to specify an informational message */
+    INFO = 030,
+    /** (`040`) the level to specify an debugging message */
+    DEBUG = 040,
+    /** (`0377` or `0xFF`) the level to enable all log messages (disables filtering of levels) */
     ALL = 0xFF
 };
-
+/**@} */
 #endif /* SRC_RF24LOGLEVEL_H_ */

--- a/src/RF24Logger.h
+++ b/src/RF24Logger.h
@@ -45,7 +45,7 @@ public:
      * @brief ouput an ERROR message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -65,7 +65,7 @@ public:
      * @brief output a message to WARN the reader
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -85,7 +85,7 @@ public:
      * @brief output an INFO message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -105,7 +105,7 @@ public:
      * @brief output a message to help developers DEBUG their source code
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -126,7 +126,7 @@ public:
      * @param logLevel the level of the logging message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */

--- a/src/RF24Logger.h
+++ b/src/RF24Logger.h
@@ -28,10 +28,11 @@
 class RF24Logger
 {
 private:
+    /** The output stream handler configured by sethandler() */
     RF24LogHandler *handler;
 
 public:
-    /** @brief Initializes the appender to nullptr */
+    /** @brief Initializes the handler to nullptr */
     RF24Logger();
 
     /**
@@ -43,8 +44,10 @@ public:
     /**
      * @brief ouput an ERROR message
      * @param vendorId A scoping identity of the message's origin
-     * @param message The message to output
-     * @param args consumable arguments
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param ... the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     template <class T>
     void error(const __FlashStringHelper *vendorId, T message, ...)
@@ -61,8 +64,10 @@ public:
     /**
      * @brief output a message to WARN the reader
      * @param vendorId A scoping identity of the message's origin
-     * @param message The message to output
-     * @param args consumable arguments
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param ... the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     template <class T>
     void warn(const __FlashStringHelper *vendorId, T message, ...)
@@ -79,8 +84,10 @@ public:
     /**
      * @brief output an INFO message
      * @param vendorId A scoping identity of the message's origin
-     * @param message The message to output
-     * @param args consumable arguments
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param ... the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     template <class T>
     void info(const __FlashStringHelper *vendorId, T message, ...)
@@ -97,8 +104,10 @@ public:
     /**
      * @brief output a message to help developers DEBUG their source code
      * @param vendorId A scoping identity of the message's origin
-     * @param message The message to output
-     * @param args consumable arguments
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param ... the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     template <class T>
     void debug(const __FlashStringHelper *vendorId, T message, ...)
@@ -114,9 +123,12 @@ public:
 
     /**
      * @brief output a log message of any level
+     * @param logLevel the level of the logging message
      * @param vendorId A scoping identity of the message's origin
-     * @param message The message to output
-     * @param args consumable arguments
+     * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
+     * but note that not all are supported on certain MCU architectures (eg `%f` for floats).
+     * @param ... the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
      */
     template <class T>
     void log(uint8_t logLevel, const __FlashStringHelper *vendorId, T message, ...)

--- a/src/RF24Logger.h
+++ b/src/RF24Logger.h
@@ -45,7 +45,7 @@ public:
      * @brief ouput an ERROR message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%F` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -65,7 +65,7 @@ public:
      * @brief output a message to WARN the reader
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%F` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -85,7 +85,7 @@ public:
      * @brief output an INFO message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%F` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -105,7 +105,7 @@ public:
      * @brief output a message to help developers DEBUG their source code
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%F` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
@@ -126,7 +126,7 @@ public:
      * @param logLevel the level of the logging message
      * @param vendorId A scoping identity of the message's origin
      * @param message The message format string. Review [the printf spcifiers](https://www.cplusplus.com/reference/cstdio/printf/),
-     * but note that not all are supported on certain MCU architectures (eg `%%f` for floats).
+     * but note that not all are supported on certain MCU architectures (eg `%%F` for floats).
      * @param ... the sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */

--- a/src/handlers/RF24AbstractLogHandler.cpp
+++ b/src/handlers/RF24AbstractLogHandler.cpp
@@ -1,5 +1,5 @@
 /**
- * @file RF24LogHandler.h
+ * @file RF24AbstractLogHandler.cpp
  *
  * Created on: 3 Apr 2021
  *     Author: Witold Markowski (wmarkow)

--- a/src/handlers/RF24AbstractLogHandler.h
+++ b/src/handlers/RF24AbstractLogHandler.h
@@ -1,5 +1,5 @@
 /**
- * @file RF24LogHandler.h
+ * @file RF24AbstractLogHandler.h
  *
  * Created on: 2 Oct 2020
  *     Author: Witold Markowski (wmarkow)

--- a/src/handlers/RF24AbstractLogHandler.h
+++ b/src/handlers/RF24AbstractLogHandler.h
@@ -52,10 +52,10 @@ protected:
 
     /**
      * write log message to its destination
-     * @param logLevel the level of the logging message
+     * @param logLevel The level of the logging message
      * @param vendorId The prefixed origin of the message
      * @param message The message
-     * @param args the sequence of variables used to replace the format specifiers in the
+     * @param args The sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
     virtual void write(uint8_t logLevel,
@@ -65,10 +65,10 @@ protected:
 
     /**
      * write log message to its destination
-     * @param logLevel the level of the logging message
+     * @param logLevel The level of the logging message
      * @param vendorId The prefixed origin of the message
      * @param message The message
-     * @param args the sequence of variables used to replace the format specifiers in the
+     * @param args The sequence of variables used to replace the format specifiers in the
      * same order for which they appear in the @p message
      */
     virtual void write(uint8_t logLevel,

--- a/src/handlers/RF24AbstractLogHandler.h
+++ b/src/handlers/RF24AbstractLogHandler.h
@@ -31,60 +31,50 @@
 class RF24AbstractLogHandler : public RF24LogHandler
 {
 public:
-      /**
-       * log message.
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      void log(uint8_t logLevel,
-               const __FlashStringHelper *vendorId,
-               const char *message,
-               va_list *args);
+    void log(uint8_t logLevel,
+             const __FlashStringHelper *vendorId,
+             const char *message,
+             va_list *args);
 
-      /**
-       * log message.
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      void log(uint8_t logLevel,
-               const __FlashStringHelper *vendorId,
-               const __FlashStringHelper *message,
-               va_list *args);
+    void log(uint8_t logLevel,
+             const __FlashStringHelper *vendorId,
+             const __FlashStringHelper *message,
+             va_list *args);
 
-      /**
-       * set the maximal level of the logged messages.
-       * @param logLevel maximal level of the logged message
-       */
-      void setLogLevel(uint8_t logLevel);
+    void setLogLevel(uint8_t logLevel);
 
 protected:
-      uint8_t logLevel;
 
-      RF24AbstractLogHandler();
+    /** The configured log level used to filter which messages are output. */
+    uint8_t logLevel;
 
-      /**
-       * write log message to its destination
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      virtual void write(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const char *message,
-                          va_list *args) = 0;
+    RF24AbstractLogHandler();
 
-      /**
-       * write log message to its destination
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      virtual void write(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const __FlashStringHelper *message,
-                          va_list *args) = 0;
+    /**
+     * write log message to its destination
+     * @param logLevel the level of the logging message
+     * @param vendorId The prefixed origin of the message
+     * @param message The message
+     * @param args the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
+     */
+    virtual void write(uint8_t logLevel,
+                       const __FlashStringHelper *vendorId,
+                       const char *message,
+                       va_list *args) = 0;
+
+    /**
+     * write log message to its destination
+     * @param logLevel the level of the logging message
+     * @param vendorId The prefixed origin of the message
+     * @param message The message
+     * @param args the sequence of variables used to replace the format specifiers in the
+     * same order for which they appear in the @p message
+     */
+    virtual void write(uint8_t logLevel,
+                       const __FlashStringHelper *vendorId,
+                       const __FlashStringHelper *message,
+                       va_list *args) = 0;
 };
 
 #endif /* SRC_HANDLERS_RF24ABSTRACTLOGHANDLER_H_ */

--- a/src/handlers/RF24DualLogHandler.h
+++ b/src/handlers/RF24DualLogHandler.h
@@ -29,6 +29,12 @@ private:
     RF24LogHandler *handler2;
 
 public:
+
+    /**
+     * @brief Instance constructor
+     * @param handler1 An output stream handler
+     * @param handler2 An output stream handler
+     */
     RF24DualLogHandler(RF24LogHandler *handler1, RF24LogHandler *handler2);
 
     void log(uint8_t logLevel,

--- a/src/handlers/RF24StreamLogHandler.cpp
+++ b/src/handlers/RF24StreamLogHandler.cpp
@@ -18,11 +18,15 @@
 
 #include "RF24StreamLogHandler.h"
 
+/** description of the @ref ERROR base level */
 const char rf24logLevelError[] = "ERROR";
+/** description of the @ref WARN base level */
 const char rf24logLevelWarn[] = " WARN";
+/** description of the @ref INFO base level */
 const char rf24logLevelInfo[] = " INFO";
+/** description of the @ref DEBUG base level */
 const char rf24logLevelDebug[] = "DEBUG";
-
+/** collection of the base level descriptions */
 const char *const rf24LogLevels[] = {rf24logLevelError,
                                      rf24logLevelWarn,
                                      rf24logLevelInfo,

--- a/src/handlers/RF24StreamLogHandler.cpp
+++ b/src/handlers/RF24StreamLogHandler.cpp
@@ -153,45 +153,45 @@ void RF24StreamLogHandler::appendLogLevel(uint8_t logLevel)
 
     switch (logMainLevel)
     {
-    case RF24LogLevel::ERROR:
-    {
-        stream->print(rf24LogLevels[0]);
-        break;
-    }
-    case RF24LogLevel::WARN:
-    {
-        stream->print(rf24LogLevels[1]);
-        break;
-    }
-    case RF24LogLevel::INFO:
-    {
-        stream->print(rf24LogLevels[2]);
-        break;
-    }
-    case RF24LogLevel::DEBUG:
-    {
-        stream->print(rf24LogLevels[3]);
-        break;
-    }
-    default:
-    {
-        // unknown
-        if (logLevel < 10)
+        case RF24LogLevel::ERROR:
         {
-            stream->print("Lvl   ");
+            stream->print(rf24LogLevels[0]);
+            break;
         }
-        else if (logLevel < 100)
+        case RF24LogLevel::WARN:
         {
-            stream->print("Lvl  ");
+            stream->print(rf24LogLevels[1]);
+            break;
         }
-        else
+        case RF24LogLevel::INFO:
         {
-            stream->print("Lvl ");
+            stream->print(rf24LogLevels[2]);
+            break;
         }
-        stream->print(logLevel);
-        stream->print(" ");
-        return;
-    }
+        case RF24LogLevel::DEBUG:
+        {
+            stream->print(rf24LogLevels[3]);
+            break;
+        }
+        default:
+        {
+            // unknown
+            if (logLevel < 10)
+            {
+                stream->print("Lvl   ");
+            }
+            else if (logLevel < 100)
+            {
+                stream->print("Lvl  ");
+            }
+            else
+            {
+                stream->print("Lvl ");
+            }
+            stream->print(logLevel);
+            stream->print(" ");
+            return;
+        }
     }
 
     if (subLevel == 0)

--- a/src/handlers/RF24StreamLogHandler.h
+++ b/src/handlers/RF24StreamLogHandler.h
@@ -26,9 +26,16 @@
 class RF24StreamLogHandler : public RF24AbstractLogHandler
 {
 protected:
+
+    /** The output stream */
     Print *stream;
 
 public:
+
+    /**
+     * @brief instance constructor
+     * @param stream The output stream to which logging messages are directed.
+     */
     RF24StreamLogHandler(Print *stream);
 
 protected:
@@ -42,11 +49,40 @@ protected:
                const __FlashStringHelper *message,
                va_list *args);
 
+    /** @brief output a timestamp */
     void appendTimestamp();
+
+    /**
+     * @brief output a description of the log level
+     * @param logLevel The level to describe.
+     */
     void appendLogLevel(uint8_t logLevel);
+
+    /**
+     * @brief output a origin of the message
+     * @param vendorId The origin name.
+     */
     void appendVendorId(const __FlashStringHelper *vendorId);
+
+    /**
+     * @brief output a message with the specifiers replaced with values from the sequence of @p args
+     * @param format the format of the message
+     * @param args the sequence of args
+     */
     void appendFormattedMessage(const char *format, va_list *args);
+
+    /**
+     * @brief output a message with the specifiers replaced with values from the sequence of @p args
+     * @param format the format of the message
+     * @param args the sequence of args
+     */
     void appendFormattedMessage(const __FlashStringHelper *format, va_list *args);
+
+    /**
+     * @brief output a message with the specifiers replaced with values from the sequence of @p args
+     * @param format the format of the message
+     * @param args the sequence of args
+     */
     void appendFormat(const char format, va_list *args);
 };
 

--- a/src/handlers/RF24StreamLogHandler.h
+++ b/src/handlers/RF24StreamLogHandler.h
@@ -66,22 +66,22 @@ protected:
 
     /**
      * @brief output a message with the specifiers replaced with values from the sequence of @p args
-     * @param format the format of the message
-     * @param args the sequence of args
+     * @param format The format of the message
+     * @param args The sequence of args
      */
     void appendFormattedMessage(const char *format, va_list *args);
 
     /**
      * @brief output a message with the specifiers replaced with values from the sequence of @p args
-     * @param format the format of the message
-     * @param args the sequence of args
+     * @param format The format of the message
+     * @param args The sequence of args
      */
     void appendFormattedMessage(const __FlashStringHelper *format, va_list *args);
 
     /**
      * @brief output a message with the specifiers replaced with values from the sequence of @p args
-     * @param format the format of the message
-     * @param args the sequence of args
+     * @param format The format of the message
+     * @param args The sequence of args
      */
     void appendFormat(const char format, va_list *args);
 };


### PR DESCRIPTION
This removes all warnings in doxygen rendering. Also I fixed the indent in _RF24AbstractHandler.h_. @wmarkow I think your IDE is defaulting to use 3 or 6 spaces.

- This should help [visualize the hierarchy of class inheritence](https://nrf24.github.io/RF24Log/hierarchy.html) as [doxygen provides some graphs](https://nrf24.github.io/RF24Log/class_r_f24_log_handler.html).
- Also worth noting that (using doxygen) docs are inherited like all other class members, so we only have to write them once 👍🏼 

@wmarkow I'll be merging all commits (no squashing/fast-forwarding) until we have a suitable foundation (or I'm told otherwise) 😉 